### PR TITLE
add new function to convert Teams citations into Webchat format

### DIFF
--- a/src/app/data/sampleActivity.ts
+++ b/src/app/data/sampleActivity.ts
@@ -7,7 +7,7 @@ export default {
 [1]: https://support.microsoft.com/en-us/windows/use-a-proxy-server-in-windows-03096c53-0554-4ffe-b6ab-8b1deee8dae1 "Use a proxy server in Windows"
 [2]: https://learn.microsoft.com/en-us/troubleshoot/windows-server/networking/configure-proxy-server-settings "Configure proxy server settings - Windows Server"
 [3]: cite:1 "Introduction Configuring proxy settings is a fundamental aspect..."
-[4]: cite:2 "This citation has no name"
+\\[4\\]: cite:2 "This citation has no name"
 `,
   entities: [
     {

--- a/src/app/ui/MarkdownTextActivity/private/getClaimsFromMarkdown.ts
+++ b/src/app/ui/MarkdownTextActivity/private/getClaimsFromMarkdown.ts
@@ -54,7 +54,6 @@ export default function* getClaimsFromMarkdown(
   text: string,
   claimsWithText: Map<string, SchemaOrgClaim & { text: string }>
 ): Generator<SchemaOrgClaim> {
-
   text = stripTeamsCitations(text);
   const tree = fromMarkdown(text);
 

--- a/src/app/ui/MarkdownTextActivity/private/getClaimsFromMarkdown.ts
+++ b/src/app/ui/MarkdownTextActivity/private/getClaimsFromMarkdown.ts
@@ -2,7 +2,7 @@
 import { fromMarkdown } from 'mdast-util-from-markdown';
 
 import onErrorResumeNext from '../../../utils/onErrorResumeNext';
-import stripMarkdown from './stripMarkdown';
+import stripMarkdown, { stripTeamsCitations } from './stripMarkdown';
 
 // import type { Reference } from '../types/Reference';
 import type { Claim as SchemaOrgClaim } from '../../../types/SchemaOrg/Claim';
@@ -54,6 +54,8 @@ export default function* getClaimsFromMarkdown(
   text: string,
   claimsWithText: Map<string, SchemaOrgClaim & { text: string }>
 ): Generator<SchemaOrgClaim> {
+
+  text = stripTeamsCitations(text);
   const tree = fromMarkdown(text);
 
   for (const node of walk(tree)) {

--- a/src/app/ui/MarkdownTextActivity/private/renderMarkdownAsHTML.ts
+++ b/src/app/ui/MarkdownTextActivity/private/renderMarkdownAsHTML.ts
@@ -81,7 +81,6 @@ export default function render(
   { markdownRespectCRLF }: { markdownRespectCRLF: boolean },
   { externalLinkAlt = '' }: { externalLinkAlt?: string } = {}
 ): string {
-
   markdown = stripTeamsCitations(markdown);
 
   if (markdownRespectCRLF) {

--- a/src/app/ui/MarkdownTextActivity/private/renderMarkdownAsHTML.ts
+++ b/src/app/ui/MarkdownTextActivity/private/renderMarkdownAsHTML.ts
@@ -8,6 +8,7 @@ import MarkdownIt from 'markdown-it';
 import markdownItAttrs from 'markdown-it-attrs-es5';
 // @ts-expect-error no typings
 import sanitizeHTML from 'sanitize-html';
+import { stripTeamsCitations } from './stripMarkdown';
 
 const SANITIZE_HTML_OPTIONS = {
   allowedAttributes: {
@@ -80,6 +81,9 @@ export default function render(
   { markdownRespectCRLF }: { markdownRespectCRLF: boolean },
   { externalLinkAlt = '' }: { externalLinkAlt?: string } = {}
 ): string {
+
+  markdown = stripTeamsCitations(markdown);
+
   if (markdownRespectCRLF) {
     markdown = markdown.replace(/\n\r|\r\n/gu, carriageReturn => (carriageReturn === '\n\r' ? '\r\n' : '\n\r'));
   }

--- a/src/app/ui/MarkdownTextActivity/private/stripMarkdown.ts
+++ b/src/app/ui/MarkdownTextActivity/private/stripMarkdown.ts
@@ -18,3 +18,13 @@ export default function stripMarkdown(markdown: string): string {
 
   return element.textContent || '';
 }
+
+export function stripTeamsCitations(markdown: string): string {
+  // replace Teams-style escaped markdown by stripping balanced backslashes before brackets; e.g. \\[1\\] -> [1]
+
+  //                        v--- first capture group is some number of backslashes
+  //                        v      v--- second capture group is the number inside the brackets
+  //                        v      v   v--- first capture group repeated
+  //                        v      v   v           v--- the value of the second capture group
+  return markdown.replace(/(\\+)\[(\d+)\1\]/giu, `[$2]`);
+}


### PR DESCRIPTION
This adds functionality to convert Teams-style citations with backslashes into the format we're used to handling.